### PR TITLE
Add navigation in ponies and tank

### DIFF
--- a/src/demo-web-app/www/ponies/main.js
+++ b/src/demo-web-app/www/ponies/main.js
@@ -126,7 +126,7 @@ define(['libs/js/gmi-mobile'], function(gmi_platform) {
     appendHorizontalRule();
     
     appendBtn("back", function(){
-        gmi.openParentExperience();
+        gmi.exit();
     });
 
     // ---------- Helper Functions ----------

--- a/src/demo-web-app/www/tanks/main.js
+++ b/src/demo-web-app/www/tanks/main.js
@@ -125,7 +125,11 @@ define(['libs/js/gmi-mobile'], function(gmi_platform) {
     appendHorizontalRule();
 
     appendBtn("back", function(){
-        gmi.openParentExperience();
+        gmi.exit();
+    });
+
+    appendBtn("open ponies", function(){
+        gmi.openExperience("ponies");
     });
 
     gmi.gameLoaded();


### PR DESCRIPTION
To be able to go back to previous  experience gmi.exit should be called.
To  be able to test back functionality from experience, tank can now open ponies.